### PR TITLE
remove shell script and relax restart time

### DIFF
--- a/recipes-connectivity/tango/files/Starter.sh
+++ b/recipes-connectivity/tango/files/Starter.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec /usr/bin/Starter `hostnamectl --transient | cut -d. -f1`

--- a/recipes-connectivity/tango/files/starter.service
+++ b/recipes-connectivity/tango/files/starter.service
@@ -9,10 +9,10 @@ Conflicts=shutdown.target
 [Service]
 User=controls
 Group=controls
-ExecStart=/usr/bin/Starter.sh
+ExecStart=/usr/bin/Starter %H
 # ExecStop=/usr/bin/astorcli %H stop
 KillMode=process
-RestartSec=1s
+RestartSec=5s
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
Remove auxiliary shell script in starter.service and increase restart time to 5s