### PR TITLE
Use gitsm:// also for cpptango-10

### DIFF
--- a/recipes-support/tango/cpptango_10.0.0.bb
+++ b/recipes-support/tango/cpptango_10.0.0.bb
@@ -11,7 +11,7 @@ DEFAULT_PREFERENCE = "-1"
 
 SRCREV = "e9e847bd56ff93057f7f99eb0675809c0063cadc"
 SRC_URI = " \
-	git://gitlab.com/tango-controls/cppTango.git;protocol=https;branch=main \
+	gitsm://gitlab.com/tango-controls/cppTango.git;protocol=https;branch=main \
 	"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Letting CMake download the submodules seems to fail randomly, depending on the Yocto version