### PR TITLE
Add Upstream-Status to omniorb patch

### DIFF
--- a/recipes-connectivity/omniorb/files/0002-python-shebang.patch
+++ b/recipes-connectivity/omniorb/files/0002-python-shebang.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [oe specfic]
+
 Index: omniORB/src/tool/omniidl/python2/scripts/omniidl.in
 ===================================================================
 --- omniORB.orig/src/tool/omniidl/python2/scripts/omniidl.in


### PR DESCRIPTION
This is mandatory for recent Yocto releases (walnascar in this case). I have only modified the patch for omniorb since I am using cpptango 10, though